### PR TITLE
Delegate method calls when an attribute does not exists as an attribute to parent class on SimpleStruct so NoMethodError will be raise as it should be in cases where the called method does not exists in the ancestors chain

### DIFF
--- a/lib/simple_response/simple_struct.rb
+++ b/lib/simple_response/simple_struct.rb
@@ -21,6 +21,8 @@ module SimpleResponse
         @attributes[name[0...-1].to_sym] = args.first
       elsif existing_attribute?(name)
         @attributes[name.to_sym]
+      else
+        super
       end
     end
 

--- a/spec/simple_response_spec.rb
+++ b/spec/simple_response_spec.rb
@@ -146,6 +146,10 @@ RSpec.describe SimpleResponse do
       expect(response).not_to respond_to(:attribute)
     end
 
+    it 'raises an error when an unexisting attribute or method is called' do
+      expect { response.unexisting_attribute }.to raise_error(NoMethodError)
+    end
+
     it 'does not respond to query methods' do
       expect(response).not_to respond_to(:attribute?)
     end


### PR DESCRIPTION
…xists as a method in a parent class, it will raise NoMethodError